### PR TITLE
Fix Rutoken ECP Bluetooth iOS sample

### DIFF
--- a/src/Xamarin.Info/Xamarin.Info.iOS/Info.plist
+++ b/src/Xamarin.Info/Xamarin.Info.iOS/Info.plist
@@ -34,5 +34,9 @@
 	<string>Xamarin.Info.iOS</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>UISupportedExternalAccessoryProtocols</key>
+	<array>
+		<string>com.aktivco.rutokenecp</string>
+	</array>
 </dict>
 </plist>

--- a/src/Xamarin.Info/Xamarin.Info.iOS/Xamarin.Info.iOS.csproj
+++ b/src/Xamarin.Info/Xamarin.Info.iOS/Xamarin.Info.iOS.csproj
@@ -161,7 +161,10 @@
     </NativeReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.293080" />
+    <PackageReference Include="Aktiv.RutokenPkcs11Interop">
+      <Version>2.0.0-alpha3</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/src/Xamarin.Info/Xamarin.Info/Xamarin.Info.csproj
+++ b/src/Xamarin.Info/Xamarin.Info/Xamarin.Info.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aktiv.RutokenPkcs11Interop" Version="2.0.0-alpha3" />
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.293080" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Upgrade to Xamarin.iOS 3.6 because of app crash
- Add Aktiv.RutokenPkcs11Interop package reference **(REMEMBER TO SET STABLE VERSION)**
- Modify Info.plist to access Rutoken ECP Bluetooth
